### PR TITLE
String token

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -271,3 +271,12 @@ func (ce *CallExpression) String() string {
 
 	return out.String()
 }
+
+type StringLiteral struct {
+	Token token.Token
+	Value string
+}
+
+func (sl *StringLiteral) expressionNode()      {}
+func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
+func (sl *StringLiteral) String() string       { return sl.Token.Literal }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -71,6 +71,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		}
 
 		return applyFunction(function, args)
+	case *ast.StringLiteral:
+		return &object.String{Value: node.Value}
 	}
 
 	return nil

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -128,6 +128,8 @@ func evalInflixExpression(operator string, left, right object.Object) object.Obj
 		return nativeBoolToBooleanObject(left != right)
 	case left.Type() != right.Type():
 		return newError("type mismatch: %s %s %s", left.Type(), operator, right.Type())
+	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ:
+		return evalStringInfixExpression(operator, left, right)
 	default:
 		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
 	}
@@ -280,4 +282,14 @@ func unwrapReturnValue(obj object.Object) object.Object {
 	}
 
 	return obj
+}
+
+func evalStringInfixExpression(operator string, left, right object.Object) object.Object {
+	if operator != "+" {
+		return newError("unknown operator: %s %s %s", left.Type(), operator, right.Type())
+	}
+
+	leftVal := left.(*object.String).Value
+	rightVal := right.(*object.String).Value
+	return &object.String{Value: leftVal + rightVal}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -287,3 +287,17 @@ func TestClosures(t *testing.T) {
 	`
 	testIntegerObject(t, testEval(input), 4)
 }
+
+func TestStringLiteral(t *testing.T) {
+	input := `"Hello World!"`
+
+	evaluated := testEval(input)
+	str, ok := evaluated.(*object.String)
+	if !ok {
+		t.Fatalf("object is not String. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	if str.Value != "Hello World!" {
+		t.Errorf("String has wrong value. got=%q", str.Value)
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -203,6 +203,7 @@ func TestErrorHandling(t *testing.T) {
 		}
 		`, "unknown operator: BOOLEAN + BOOLEAN"},
 		{"foobar", "identifier not found: foobar"},
+		{`"Hello" - "World"`, "unknown operator: STRING - STRING"},
 	}
 
 	for _, tt := range tests {
@@ -290,6 +291,20 @@ func TestClosures(t *testing.T) {
 
 func TestStringLiteral(t *testing.T) {
 	input := `"Hello World!"`
+
+	evaluated := testEval(input)
+	str, ok := evaluated.(*object.String)
+	if !ok {
+		t.Fatalf("object is not String. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	if str.Value != "Hello World!" {
+		t.Errorf("String has wrong value. got=%q", str.Value)
+	}
+}
+
+func TestStringConcatenation(t *testing.T) {
+	input := `"Hello" + " " + "World!"`
 
 	evaluated := testEval(input)
 	str, ok := evaluated.(*object.String)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -83,6 +83,9 @@ func (l *Lexer) NextToken() token.Token{
 		tok = newToken(token.LBRACE, l.ch)
 	case '}':
 		tok = newToken(token.RBRACE, l.ch)
+	case '"':
+		tok.Type = token.STRING
+		tok.Literal = l.readString()
 	case 0:
 		tok.Literal = ""
 		tok.Type = token.EOF
@@ -139,4 +142,15 @@ func (l *Lexer)skipWhitespace(){
 	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
 		l.readChar()
 	}
+}
+
+func (l *Lexer) readString() string {
+	position := l.position + 1
+	for {
+		l.readChar()
+		if l.ch == '"' || l.ch == 0 {
+			break
+		}
+	}
+	return l.input[position:l.position]
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -24,6 +24,9 @@ if (5 < 10) {
 
 10 == 10;
 10 != 9;
+
+"foobar"
+"foo bar"
 `
 
 	tests := []struct{
@@ -103,6 +106,8 @@ if (5 < 10) {
 		{token.NOT_EQ, "!="},
 		{token.INT, "9"},
 		{token.SEMICOLON, ";"},
+		{token.STRING, "foobar"},
+		{token.STRING, "foo bar"},
 		{token.EOF, ""},
 	}
 

--- a/object/object.go
+++ b/object/object.go
@@ -17,6 +17,8 @@ const (
 	ERROR_OBJ = "ERROR"
 
 	FUNCTION_OBJ = "FUNCTION"
+
+	STRING_OBJ = "STRING"
 )
 
 type ObjectType string
@@ -81,3 +83,10 @@ func (f *Function) Inspect() string {
 
 	return out.String()
 }
+
+type String struct {
+	Value string
+}
+
+func (s *String) Type() ObjectType { return STRING_OBJ }
+func (s *String) Inspect() string { return s.Value }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -64,6 +64,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
+	p.registerPrefix(token.STRING, p.parseStringLiteral)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -434,4 +435,8 @@ func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
 	}
 
 	return list
+}
+
+func (p *Parser) parseStringLiteral() ast.Expression {
+	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -676,6 +676,26 @@ func TestCallExpressionParsing(t *testing.T) {
 	testInfixExpression(t, exp.Arguments[2], 4, "+", 5)
 }
 
+func TestStringLiteralExpression(t *testing.T) {
+	input := `"hello world";`
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	str, ok := stmt.Expression.(*ast.StringLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.StringLiteral. got=%T", stmt.Expression)
+	}
+
+	if str.Value != "hello world" {
+		t.Errorf("str.Value not %q. got=%q", "hello world", str.Value)
+	}
+}
+
 func checkParserErrors(t *testing.T, p *Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {

--- a/token/token.go
+++ b/token/token.go
@@ -41,6 +41,8 @@ const (
 	RETURN = "RETURN"
 	EQ = "=="
 	NOT_EQ = "!="
+
+	STRING = "STRING"
 )
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
This pull request introduces support for string literals in the interpreter. The changes span multiple files and include updates to the lexer, parser, evaluator, and corresponding tests.

### Support for String Literals:

* [`ast/ast.go`](diffhunk://#diff-9dcefbf65d58a909b6cc7332b7985d070382bf920a4b13c7acea4ee91ecdf5acR274-R282): Added a new `StringLiteral` type to represent string literals in the AST.
* [`object/object.go`](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR20-R21): Introduced a new `String` type to represent string objects and added a corresponding `STRING_OBJ` constant. [[1]](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR20-R21) [[2]](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR86-R92)

### Lexer Updates:

* [`lexer/lexer.go`](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR86-R88): Modified the lexer to recognize string literals and added a `readString` method to handle string tokenization. [[1]](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR86-R88) [[2]](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR146-R156)
* [`lexer/lexer_test.go`](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR27-R29): Added test cases to ensure the lexer correctly identifies string literals. [[1]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR27-R29) [[2]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR109-R110)

### Parser Updates:

* [`parser/parser.go`](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R67): Registered a prefix parse function for string literals and implemented the `parseStringLiteral` method. [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R67) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R439-R442)
* [`parser/parser_test.go`](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faR679-R698): Added test cases to verify the parsing of string literals.

### Evaluator Updates:

* [`evaluator/evaluator.go`](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R74-R75): Extended the evaluator to handle string literals and string infix expressions (concatenation). [[1]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R74-R75) [[2]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R131-R132) [[3]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R286-R295)
* [`evaluator/evaluator_test.go`](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR291-R318): Added test cases for string literal evaluation and string concatenation. [[1]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR291-R318) [[2]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR206)

### Token Updates:

* [`token/token.go`](diffhunk://#diff-33bf6304dd970a085d3e7819ae65390a9c7fd1fe65eee30f0dc82021ff6975e0R44-R45): Added a new `STRING` token type.