### PR TITLE
Add array

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -280,3 +280,25 @@ type StringLiteral struct {
 func (sl *StringLiteral) expressionNode()      {}
 func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
 func (sl *StringLiteral) String() string       { return sl.Token.Literal }
+
+type ArrayLiteral struct {
+	Token    token.Token // The '[' token
+	Elements []Expression
+}
+
+func (al *ArrayLiteral) expressionNode()      {}
+func (al *ArrayLiteral) TokenLiteral() string { return al.Token.Literal }
+func (al *ArrayLiteral) String() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, el := range al.Elements {
+		elements = append(elements, el.String())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -86,6 +86,10 @@ func (l *Lexer) NextToken() token.Token{
 	case '"':
 		tok.Type = token.STRING
 		tok.Literal = l.readString()
+	case '[':
+		tok = newToken(token.LBRACKET, l.ch)
+	case ']':
+		tok = newToken(token.RBRACKET, l.ch)
 	case 0:
 		tok.Literal = ""
 		tok.Type = token.EOF

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -27,6 +27,8 @@ if (5 < 10) {
 
 "foobar"
 "foo bar"
+
+[1, 2];
 `
 
 	tests := []struct{
@@ -108,6 +110,12 @@ if (5 < 10) {
 		{token.SEMICOLON, ";"},
 		{token.STRING, "foobar"},
 		{token.STRING, "foo bar"},
+		{token.LBRACKET, "["},
+		{token.INT, "1"},
+		{token.COMMA, ","},
+		{token.INT, "2"},
+		{token.RBRACKET, "]"},
+		{token.SEMICOLON, ";"},
 		{token.EOF, ""},
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -65,6 +65,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.IF, p.parseIfExpression)
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
+	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -440,3 +441,11 @@ func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
 func (p *Parser) parseStringLiteral() ast.Expression {
 	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
 }
+
+func (p *Parser) parseArrayLiteral() ast.Expression {
+	array := &ast.ArrayLiteral{Token: p.curToken}
+	array.Elements = p.parseExpressionList(token.RBRACKET)
+	return array
+}
+
+

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -696,6 +696,30 @@ func TestStringLiteralExpression(t *testing.T) {
 	}
 }
 
+func TestParsingArrayLiterals(t *testing.T) {
+	input := "[1, 2 * 2, 3 + 3]"
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	array, ok := stmt.Expression.(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.ArrayLiteral. got=%T", stmt.Expression)
+	}
+
+	if len(array.Elements) != 3 {
+		t.Fatalf("len(array.Elements) not 3. got=%d", len(array.Elements))
+	}
+
+	testIntegerLiteral(t, array.Elements[0], 1)
+	testInfixExpression(t, array.Elements[1], 2, "*", 2)
+	testInfixExpression(t, array.Elements[2], 3, "+", 3)
+}
+
 func checkParserErrors(t *testing.T, p *Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {

--- a/token/token.go
+++ b/token/token.go
@@ -43,6 +43,9 @@ const (
 	NOT_EQ = "!="
 
 	STRING = "STRING"
+
+	LBRACKET = "["
+	RBRACKET = "]"
 )
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
This pull request introduces support for array literals in the codebase. The changes include modifications to the lexer, parser, and associated tests to handle array literals correctly.

Key changes:

### AST and Token Handling:
* Added `ArrayLiteral` struct and associated methods to the AST (`ast/ast.go`).
* Introduced new token types `LBRACKET` and `RBRACKET` for array literals (`token/token.go`).

### Lexer Updates:
* Updated the lexer to recognize `[` and `]` as new tokens (`lexer/lexer.go`).

### Parser Enhancements:
* Registered a new prefix parse function for `LBRACKET` to handle array literals (`parser/parser.go`).
* Implemented the `parseArrayLiteral` method in the parser to parse array literals (`parser/parser.go`).

### Test Cases:
* Added test cases to ensure correct tokenization of array literals (`lexer/lexer_test.go`). [[1]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR30-R31) [[2]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR113-R118)
* Added a new test to verify the parsing of array literals (`parser/parser_test.go`).