### PR TITLE
Add array index

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -302,3 +302,24 @@ func (al *ArrayLiteral) String() string {
 
 	return out.String()
 }
+
+type IndexExpression struct {
+	Token token.Token // The '[' token
+	Left  Expression
+	Index Expression
+}
+
+func (ie *IndexExpression) expressionNode()      {}
+func (ie *IndexExpression) TokenLiteral() string { return ie.Token.Literal }
+
+func (ie *IndexExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(ie.Left.String())
+	out.WriteString("[")
+	out.WriteString(ie.Index.String())
+	out.WriteString("])")
+
+	return out.String()
+}

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -13,6 +13,8 @@ var builtins = map[string]*object.Builtin{
 			switch arg := args[0].(type) {
 			case *object.String:
 				return &object.Integer{Value: int64(len(arg.Value))}
+			case *object.Array:
+				return &object.Integer{Value: int64(len(arg.Elements))}
 			default:
 				return newError("argument to `len` not supported, got %s",
 					args[0].Type())

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -73,6 +73,22 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return applyFunction(function, args)
 	case *ast.StringLiteral:
 		return &object.String{Value: node.Value}
+	case *ast.ArrayLiteral:
+		elements := evalExpressions(node.Elements, env)
+		if len(elements) == 1 && isError(elements[0]) {
+			return elements[0]
+		}
+		return &object.Array{Elements: elements}
+	case *ast.IndexExpression:
+		left := Eval(node.Left, env)
+		if isError(left) {
+			return left
+		}
+		index := Eval(node.Index, env)
+		if isError(index) {
+			return index
+		}
+		return evalIndexExpression(left, index)
 	}
 
 	return nil
@@ -260,14 +276,6 @@ func evalExpressions(exps []ast.Expression, env *object.Environment) []object.Ob
 }
 
 func applyFunction(fn object.Object, args []object.Object) object.Object {
-	// function, ok := fn.(*object.Function)
-	// if !ok {
-	// 	return newError("not a function: %s", fn.Type())
-	// }
-
-	// extendedEnv := extendFunctionEnv(function, args)
-	// evaluated := Eval(function.Body, extendedEnv)
-	// return unwrapReturnValue(evaluated)
 	switch fn := fn.(type) {
 	case *object.Function:
 		extendedEnv := extendFunctionEnv(fn, args)
@@ -306,4 +314,25 @@ func evalStringInfixExpression(operator string, left, right object.Object) objec
 	leftVal := left.(*object.String).Value
 	rightVal := right.(*object.String).Value
 	return &object.String{Value: leftVal + rightVal}
+}
+
+func evalIndexExpression(left, index object.Object) object.Object {
+	switch {
+	case left.Type() == object.ARRAY_OBJ && index.Type() == object.INTEGER_OBJ:
+		return evalArrayIndexExpression(left, index)
+	default:
+		return newError("index operator not supported: %s", left.Type())
+	}
+}
+
+func evalArrayIndexExpression(array, index object.Object) object.Object {
+	arrayObject := array.(*object.Array)
+	idx := index.(*object.Integer).Value
+	max := int64(len(arrayObject.Elements) - 1)
+
+	if idx < 0 || idx > max {
+		return NULL
+	}
+
+	return arrayObject.Elements[idx]
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -346,3 +346,49 @@ func TestBuiltinFunctions(t *testing.T) {
 		}
 	}
 }
+
+func TestArrayLiterals(t *testing.T) {
+	input := "[1, 2 * 2, 3 + 3]"
+	
+	evaluated := testEval(input)
+	result, ok := evaluated.(*object.Array)
+	if !ok {
+		t.Fatalf("object is not Array. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	if len(result.Elements) != 3 {
+		t.Fatalf("array has wrong number of elements. got=%d", len(result.Elements))
+	}
+
+	testIntegerObject(t, result.Elements[0], 1)
+	testIntegerObject(t, result.Elements[1], 4)
+	testIntegerObject(t, result.Elements[2], 6)
+}
+
+func TestArrayIndexExpressions(t *testing.T) {
+	tests := []struct {
+		input string
+		expected interface{}
+	}{
+		{"[1, 2, 3][0]", 1},
+		{"[1, 2, 3][1]", 2},
+		{"[1, 2, 3][2]", 3},
+		{"let i = 0; [1][i];", 1},
+		{"[1, 2, 3][1 + 1];", 3},
+		{"let myArray = [1, 2, 3]; myArray[2];", 3},
+		{"let myArray = [1, 2, 3]; myArray[0] + myArray[1] + myArray[2];", 6},
+		{"let myArray = [1, 2, 3]; let i = myArray[0]; myArray[i]", 2},
+		{"[1, 2, 3][3]", nil},
+		{"[1, 2, 3][-1]", nil},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		switch expected := tt.expected.(type) {
+		case int:
+			testIntegerObject(t, evaluated, int64(expected))
+		default:
+			testNullObject(t, evaluated)
+		}
+	}
+}

--- a/object/object.go
+++ b/object/object.go
@@ -21,6 +21,8 @@ const (
 	STRING_OBJ = "STRING"
 
 	BUILTIN_OBJ = "BUILTIN"
+
+	ARRAY_OBJ = "ARRAY"
 )
 
 type ObjectType string
@@ -101,3 +103,23 @@ type Builtin struct {
 
 func (b *Builtin) Type() ObjectType { return BUILTIN_OBJ }
 func (b *Builtin) Inspect() string { return "builtin function" }
+
+type Array struct {
+	Elements []Object
+}
+
+func (ao *Array) Type() ObjectType { return ARRAY_OBJ }
+func (ao *Array) Inspect() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, el := range ao.Elements {
+		elements = append(elements, el.Inspect())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -507,6 +507,14 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 			"add(a + b + c * d / f + g)",
 			"add((((a + b) + ((c * d) / f)) + g))",
 		},
+		{
+			"a * [1, 2, 3, 4][b * c] * d",
+			"((a * ([1, 2, 3, 4][(b * c)])) * d)",
+		},
+		{
+			"add(a * b[2], b[1], 2 * [1, 2][1])",
+			"add((a * (b[2])), (b[1]), (2 * ([1, 2][1])))",
+		},
 	}
 
 	for _, tt := range tests {
@@ -718,6 +726,30 @@ func TestParsingArrayLiterals(t *testing.T) {
 	testIntegerLiteral(t, array.Elements[0], 1)
 	testInfixExpression(t, array.Elements[1], 2, "*", 2)
 	testInfixExpression(t, array.Elements[2], 3, "+", 3)
+}
+
+func TestParsingIndexExpressions(t *testing.T) {
+	input := "myArray[1 + 1]"
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	indexExp, ok := stmt.Expression.(*ast.IndexExpression)
+	if !ok {
+		t.Fatalf("exp not *ast.IndexExpression. got=%T", stmt.Expression)
+	}
+
+	if !testIdentifier(t, indexExp.Left, "myArray") {
+		return
+	}
+
+	if !testInfixExpression(t, indexExp.Index, 1, "+", 1) {
+		return
+	}
 }
 
 func checkParserErrors(t *testing.T, p *Parser) {


### PR DESCRIPTION
This pull request introduces support for array literals and index expressions in the language. The changes span multiple files and add new types, evaluation logic, parsing rules, and corresponding tests.

### Added support for array literals and index expressions:

* [`ast/ast.go`](diffhunk://#diff-9dcefbf65d58a909b6cc7332b7985d070382bf920a4b13c7acea4ee91ecdf5acR305-R325): Introduced a new `IndexExpression` type and implemented its methods.

### Evaluation logic for arrays and index expressions:

* [`evaluator/evaluator.go`](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R76-R91): Added cases for `ArrayLiteral` and `IndexExpression` in the `Eval` function. Implemented `evalIndexExpression` and `evalArrayIndexExpression` functions. [[1]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R76-R91) [[2]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R318-R338)
* [`evaluator/builtins.go`](diffhunk://#diff-d231af81d2985497b7b1365c73c44cdef765f600f493ffb8b8f0e1c7d1eac88bR16-R17): Extended the `len` function to support arrays.

### Parsing rules for arrays and index expressions:

* [`parser/parser.go`](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R20): Added a new precedence for `INDEX` and registered the parsing function for `LBRACKET`. Implemented the `parseIndexExpression` function. [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R20) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R35) [[3]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794L79-R82) [[4]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R453-R465)

### Tests for arrays and index expressions:

* [`evaluator/evaluator_test.go`](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR349-R394): Added tests for array literals and index expressions.
* [`parser/parser_test.go`](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faR510-R517): Added tests for parsing array literals and index expressions. [[1]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faR510-R517) [[2]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faR731-R754)

### New object types:

* [`object/object.go`](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR24-R25): Introduced a new `Array` type and its methods. [[1]](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR24-R25) [[2]](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR106-R125)