### PR TITLE
add: implement built-in functions for array manipulation (first, last, rest, push)

### DIFF
--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -21,4 +21,86 @@ var builtins = map[string]*object.Builtin{
 			}
 		},
 	},
+	"first": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `first` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*object.Array)
+			if len(arr.Elements) > 0 {
+				return arr.Elements[0]
+			}
+
+			return NULL
+		},
+	},
+	"last": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `last` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				return arr.Elements[length-1]
+			}
+
+			return NULL
+		},
+	},
+	"rest": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `rest` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				newElements := make([]object.Object, length-1, length-1)
+				copy(newElements, arr.Elements[1:length])
+				return &object.Array{Elements: newElements}
+			}
+
+			return NULL
+		},
+	},
+	"push": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 2 {
+				return newError("wrong number of arguments. got=%d, want=2",
+					len(args))
+			}
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `push` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+
+			newElements := make([]object.Object, length+1, length+1)
+			copy(newElements, arr.Elements)
+			newElements[length] = args[1]
+
+			return &object.Array{Elements: newElements}
+		},
+	},
 }


### PR DESCRIPTION
This pull request introduces several new built-in functions to the `evaluator` package to enhance array manipulation capabilities. These functions include `first`, `last`, `rest`, and `push`.

New built-in functions for array manipulation:

* [`first`](diffhunk://#diff-d231af81d2985497b7b1365c73c44cdef765f600f493ffb8b8f0e1c7d1eac88bR24-R105): Returns the first element of an array. Returns an error if the argument is not an array or if the number of arguments is incorrect.
* [`last`](diffhunk://#diff-d231af81d2985497b7b1365c73c44cdef765f600f493ffb8b8f0e1c7d1eac88bR24-R105): Returns the last element of an array. Returns an error if the argument is not an array or if the number of arguments is incorrect.
* [`rest`](diffhunk://#diff-d231af81d2985497b7b1365c73c44cdef765f600f493ffb8b8f0e1c7d1eac88bR24-R105): Returns all elements of an array except the first one. Returns an error if the argument is not an array or if the number of arguments is incorrect.
* [`push`](diffhunk://#diff-d231af81d2985497b7b1365c73c44cdef765f600f493ffb8b8f0e1c7d1eac88bR24-R105): Adds an element to the end of an array and returns the new array. Returns an error if the first argument is not an array or if the number of arguments is incorrect.