### PR TITLE
Add hash

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -323,3 +323,26 @@ func (ie *IndexExpression) String() string {
 
 	return out.String()
 }
+
+type HashLiteral struct {
+	Token token.Token // The '{' token
+	Pairs map[Expression]Expression
+}
+
+func (hl *HashLiteral) expressionNode()      {}
+func (hl *HashLiteral) TokenLiteral() string { return hl.Token.Literal }
+
+func (hl *HashLiteral) String() string {
+	var out bytes.Buffer
+	pairs := []string{}
+
+	for key, value := range hl.Pairs {
+		pairs = append(pairs, key.String()+" "+value.String())
+	}
+
+	out.WriteString("{")
+	out.WriteString(strings.Join(pairs, ", "))
+	out.WriteString("}")
+
+	return out.String()
+}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -322,6 +322,8 @@ func evalIndexExpression(left, index object.Object) object.Object {
 	switch {
 	case left.Type() == object.ARRAY_OBJ && index.Type() == object.INTEGER_OBJ:
 		return evalArrayIndexExpression(left, index)
+	case left.Type() == object.HASH_OBJ:
+		return evalHashIndexExpression(left, index)
 	default:
 		return newError("index operator not supported: %s", left.Type())
 	}
@@ -363,4 +365,20 @@ func evalHashLiteral(node *ast.HashLiteral, env *object.Environment) object.Obje
 	}
 
 	return &object.Hash{Pairs: pairs}
+}
+
+func evalHashIndexExpression(hash, index object.Object) object.Object {
+	hashObject := hash.(*object.Hash)
+
+	key, ok := index.(object.Hashable)
+	if !ok {
+		return newError("unusable as hash key: %s", index.Type())
+	}
+
+	pair, ok := hashObject.Pairs[key.HashKey()]
+	if !ok {
+		return NULL
+	}
+
+	return pair.Value
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -89,6 +89,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return index
 		}
 		return evalIndexExpression(left, index)
+	case *ast.HashLiteral:
+		return evalHashLiteral(node, env)
 	}
 
 	return nil
@@ -335,4 +337,30 @@ func evalArrayIndexExpression(array, index object.Object) object.Object {
 	}
 
 	return arrayObject.Elements[idx]
+}
+
+func evalHashLiteral(node *ast.HashLiteral, env *object.Environment) object.Object {
+	pairs := make(map[object.HashKey]object.HashPair)
+
+	for keyNode, valueNode := range node.Pairs {
+		key := Eval(keyNode, env)
+		if isError(key) {
+			return key
+		}
+
+		hashKey, ok := key.(object.Hashable)
+		if !ok {
+			return newError("unusable as hash key: %s", key.Type())
+		}
+
+		value := Eval(valueNode, env)
+		if isError(value) {
+			return value
+		}
+
+		hashed := hashKey.HashKey()
+		pairs[hashed] = object.HashPair{Key: key, Value: value}
+	}
+
+	return &object.Hash{Pairs: pairs}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -392,3 +392,43 @@ func TestArrayIndexExpressions(t *testing.T) {
 		}
 	}
 }
+
+func TestHashLiterals(t *testing.T) {
+	input := `let two = "two";
+	{
+		"one": 10 - 9,
+		two: 1 + 1,
+		"thr" + "ee": 6 / 2,
+		4: 4,
+		true: 5,
+		false: 6
+	}`
+
+	evaluated := testEval(input)
+	result, ok := evaluated.(*object.Hash)
+	if !ok {
+		t.Fatalf("Eval didn't return Hash. got=%T (%+v)", evaluated, evaluated)
+	}
+
+	expected := map[object.HashKey]int64{
+		(&object.String{Value: "one"}).HashKey(): 1,
+		(&object.String{Value: "two"}).HashKey(): 2,
+		(&object.String{Value: "three"}).HashKey(): 3,
+		(&object.Integer{Value: 4}).HashKey(): 4,
+		TRUE.HashKey(): 5,
+		FALSE.HashKey(): 6,
+	}
+
+	if len(result.Pairs) != len(expected) {
+		t.Fatalf("Hash has wrong number of pairs. got=%d", len(result.Pairs))
+	}
+
+	for expectedKey, expectedValue := range expected {
+		pair, ok := result.Pairs[expectedKey]
+		if !ok {
+			t.Errorf("no pair for given key in Pairs")
+		}
+
+		testIntegerObject(t, pair.Value, expectedValue)
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -204,6 +204,7 @@ func TestErrorHandling(t *testing.T) {
 		`, "unknown operator: BOOLEAN + BOOLEAN"},
 		{"foobar", "identifier not found: foobar"},
 		{`"Hello" - "World"`, "unknown operator: STRING - STRING"},
+		{`{"name": "Monkey"}[fn(x) { x }];`, "unusable as hash key: FUNCTION"},
 	}
 
 	for _, tt := range tests {
@@ -430,5 +431,30 @@ func TestHashLiterals(t *testing.T) {
 		}
 
 		testIntegerObject(t, pair.Value, expectedValue)
+	}
+}
+
+func TestHashIndexExpressions(t *testing.T) {
+	tests := []struct {
+		input string
+		expected interface{}
+	}{
+		{`{"foo": 5}["foo"]`, 5},
+		{`{"foo": 5}["bar"]`, nil},
+		{`let key = "foo"; {"foo": 5}[key]`, 5},
+		{`{}["foo"]`, nil},
+		{`{5: 5}[5]`, 5},
+		{`{true: 5}[true]`, 5},
+		{`{false: 5}[false]`, 5},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		switch expected := tt.expected.(type) {
+		case int:
+			testIntegerObject(t, evaluated, int64(expected))
+		default:
+			testNullObject(t, evaluated)
+		}
 	}
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -90,6 +90,8 @@ func (l *Lexer) NextToken() token.Token{
 		tok = newToken(token.LBRACKET, l.ch)
 	case ']':
 		tok = newToken(token.RBRACKET, l.ch)
+	case ':':
+		tok = newToken(token.COLON, l.ch)
 	case 0:
 		tok.Literal = ""
 		tok.Type = token.EOF

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -29,6 +29,7 @@ if (5 < 10) {
 "foo bar"
 
 [1, 2];
+{foo: "bar"}
 `
 
 	tests := []struct{
@@ -116,6 +117,11 @@ if (5 < 10) {
 		{token.INT, "2"},
 		{token.RBRACKET, "]"},
 		{token.SEMICOLON, ";"},
+		{token.LBRACE, "{"},
+		{token.IDENT, "foo"},
+		{token.COLON, ":"},
+		{token.STRING, "bar"},
+		{token.RBRACE, "}"},
 		{token.EOF, ""},
 	}
 

--- a/object/object.go
+++ b/object/object.go
@@ -3,8 +3,8 @@ package object
 import (
 	"bytes"
 	"fmt"
+	"hash/fnv"
 	"strings"
-
 	"monkey/ast"
 )
 
@@ -23,6 +23,8 @@ const (
 	BUILTIN_OBJ = "BUILTIN"
 
 	ARRAY_OBJ = "ARRAY"
+
+	HASH_OBJ = "HASH"
 )
 
 type ObjectType string
@@ -122,4 +124,59 @@ func (ao *Array) Inspect() string {
 	out.WriteString("]")
 
 	return out.String()
+}
+
+type HashKey struct {
+	Type ObjectType
+	Value uint64
+}
+
+func (b *Boolean) HashKey() HashKey {
+	var value uint64
+	if b.Value {
+		value = 1
+	} else {
+		value = 0
+	}
+
+	return HashKey{Type: b.Type(), Value: value}
+}
+
+func (i *Integer) HashKey() HashKey {
+	return HashKey{Type: i.Type(), Value: uint64(i.Value)}
+}
+
+func (s *String) HashKey() HashKey {
+	h := fnv.New64a()
+	h.Write([]byte(s.Value))
+	return HashKey{Type: s.Type(), Value: h.Sum64()}
+}
+
+type HashPair struct {
+	Key Object
+	Value Object
+}
+
+type Hash struct {
+	Pairs map[HashKey]HashPair
+}
+
+func (h *Hash) Type() ObjectType { return HASH_OBJ }
+func (h *Hash) Inspect() string {
+	var out bytes.Buffer
+
+	pairs := []string{}
+	for _, pair := range h.Pairs {
+		pairs = append(pairs, fmt.Sprintf("%s: %s", pair.Key.Inspect(), pair.Value.Inspect()))
+	}
+
+	out.WriteString("{")
+	out.WriteString(strings.Join(pairs, ", "))
+	out.WriteString("}")
+
+	return out.String()
+}
+
+type Hashable interface {
+	HashKey() HashKey
 }

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -1,0 +1,22 @@
+package object
+
+import "testing"
+
+func TestStringHashkey(t *testing.T) {
+	hello1 := &String{Value: "Hello World"}
+	hello2 := &String{Value: "Hello World"}
+	diff1 := &String{Value: "My name is johnny"}
+	diff2 := &String{Value: "My name is johnny"}
+
+	if hello1.HashKey() != hello2.HashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if diff1.HashKey() != diff2.HashKey() {
+		t.Errorf("strings with same content have different hash keys")
+	}
+
+	if hello1.HashKey() == diff1.HashKey() {
+		t.Errorf("strings with different content have same hash keys")
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -68,6 +68,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.FUNCTION, p.parseFunctionLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
 	p.registerPrefix(token.LBRACKET, p.parseArrayLiteral)
+	p.registerPrefix(token.LBRACE, p.parseHashLiteral)
 
 	p.infixParseFns = make(map[token.TokenType]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)
@@ -461,6 +462,35 @@ func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 	}
 
 	return exp
+}
+
+func (p *Parser) parseHashLiteral() ast.Expression {
+	hash := &ast.HashLiteral{Token: p.curToken}
+	hash.Pairs = make(map[ast.Expression]ast.Expression)
+
+	for !p.peekTokenIs(token.RBRACE) {
+		p.nextToken()
+		key := p.parseExpression(LOWEST)
+
+		if !p.expectPeek(token.COLON) {
+			return nil
+		}
+
+		p.nextToken()
+		value := p.parseExpression(LOWEST)
+
+		hash.Pairs[key] = value
+
+		if !p.peekTokenIs(token.RBRACE) && !p.expectPeek(token.COMMA) {
+			return nil
+		}
+	}
+
+	if !p.expectPeek(token.RBRACE) {
+		return nil
+	}
+
+	return hash
 }
 
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -752,6 +752,110 @@ func TestParsingIndexExpressions(t *testing.T) {
 	}
 }
 
+func TestParsingHashLiteralsStringKeys(t *testing.T) {
+	input := `{"one": 1, "two": 2, "three": 3}`
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	hash, ok := stmt.Expression.(*ast.HashLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.HashLiteral. got=%T", stmt.Expression)
+	}
+
+	if len(hash.Pairs) != 3 {
+		t.Errorf("hash.Pairs has wrong length. got=%d", len(hash.Pairs))
+	}
+
+	expected := map[string]int64{
+		"one": 1,
+		"two": 2,
+		"three": 3,
+	}
+
+	for k, v := range hash.Pairs {
+		literal, ok := k.(*ast.StringLiteral)
+		if !ok {
+			t.Errorf("key is not *ast.StringLiteral. got=%T", k)
+		}
+
+		expectedValue := expected[literal.Value]
+		testIntegerLiteral(t, v, expectedValue)
+	}
+}
+
+func TestParsingEmptyHashLiteral(t *testing.T) {
+	input := "{}"
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	hash, ok := stmt.Expression.(*ast.HashLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.HashLiteral. got=%T", stmt.Expression)
+	}
+
+	if len(hash.Pairs) != 0 {
+		t.Errorf("hash.Pairs has wrong length. got=%d", len(hash.Pairs))
+	}
+}
+
+func TestParsingHashLiteralsWithExpressions(t *testing.T) {
+	input := `{"one": 0 + 1, "two": 10 - 8, "three": 15 / 5}`
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	hash, ok := stmt.Expression.(*ast.HashLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.HashLiteral. got=%T", stmt.Expression)
+	}
+
+	if len(hash.Pairs) != 3 {
+		t.Errorf("hash.Pairs has wrong length. got=%d", len(hash.Pairs))
+	}
+
+	tests := map[string]func(ast.Expression){
+		"one": func(e ast.Expression) {
+			testInfixExpression(t, e, 0, "+", 1)
+		},
+		"two": func(e ast.Expression) {
+			testInfixExpression(t, e, 10, "-", 8)
+		},
+		"three": func(e ast.Expression) {
+			testInfixExpression(t, e, 15, "/", 5)
+		},
+	}
+
+	for k, v := range hash.Pairs {
+		literal, ok := k.(*ast.StringLiteral)
+		if !ok {
+			t.Errorf("key is not *ast.StringLiteral. got=%T", k)
+			continue
+		}
+
+		testFunc, ok := tests[literal.Value]
+		if !ok {
+			t.Errorf("no test function for key %q found", literal.Value)
+			continue
+		}
+
+		testFunc(v)
+	}
+}
+
 func checkParserErrors(t *testing.T, p *Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {

--- a/token/token.go
+++ b/token/token.go
@@ -46,6 +46,8 @@ const (
 
 	LBRACKET = "["
 	RBRACKET = "]"
+
+	COLON = ":"
 )
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
This pull request introduces support for hash literals in the Monkey interpreter. The changes span multiple files, including the lexer, parser, evaluator, and associated tests. The key changes include adding the necessary token types, parsing logic, evaluation logic for hash literals, and tests to ensure the correct functionality.

### Support for Hash Literals:

* **Lexer Updates:**
  * Added a new token type `COLON` to handle key-value pairs in hash literals. (`[lexer/lexer.goR93-R94](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR93-R94)`)
  * Updated lexer tests to include hash literal syntax. (`[[1]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR32)`, `[[2]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR120-R124)`)

* **Parser Updates:**
  * Registered a new prefix parse function for hash literals. (`[parser/parser.goR71](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R71)`)
  * Implemented the `parseHashLiteral` function to parse hash literals. (`[parser/parser.goR467-R495](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R467-R495)`)
  * Added tests for parsing hash literals with string keys, empty hash literals, and hash literals with expressions. (`[parser/parser_test.goR755-R858](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faR755-R858)`)

* **Evaluator Updates:**
  * Added evaluation logic for hash literals and hash index expressions. (`[[1]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R92-R93)`, `[[2]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R325-R326)`, `[[3]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R343-R384)`)
  * Included tests for evaluating hash literals and hash index expressions. (`[[1]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR207)`, `[[2]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR396-R460)`)

* **Object System Updates:**
  * Introduced `HashKey`, `HashPair`, and `Hash` types to represent hash objects. (`[object/object.goR128-R182](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR128-R182)`)
  * Implemented the `Hashable` interface for `Boolean`, `Integer`, and `String` types. (`[object/object.goR128-R182](diffhunk://#diff-ca174380c96234968edf50824defac868202575d8d594273871e861637b88fdeR128-R182)`)
  * Added tests to verify the correctness of the `HashKey` implementation. (`[object/object_test.goR1-R22](diffhunk://#diff-be3cdaff6ef751e7eff0f8963a9ce0b375e03f870519c96892e9dd7d70e023dfR1-R22)`)

* **AST Updates:**
  * Added a new `HashLiteral` struct to represent hash literals in the AST. (`[ast/ast.goR326-R348](diffhunk://#diff-9dcefbf65d58a909b6cc7332b7985d070382bf920a4b13c7acea4ee91ecdf5acR326-R348)`)