### PR TITLE
add: implement 'puts' built-in function for printing arguments

### DIFF
--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -103,4 +103,13 @@ var builtins = map[string]*object.Builtin{
 			return &object.Array{Elements: newElements}
 		},
 	},
+	"puts": &object.Builtin{
+		Fn: func(args ...object.Object) object.Object {
+			for _, arg := range args {
+				println(arg.Inspect())
+			}
+
+			return NULL
+		},
+	},
 }


### PR DESCRIPTION
This pull request introduces a new built-in function to the `evaluator/builtins.go` file. The change adds the `puts` function, which prints each of its arguments and returns `NULL`.

Key change:

* Added a new built-in function `puts` to the `var builtins` map. The `puts` function iterates over its arguments, prints each one using `println(arg.Inspect())`, and returns `NULL`.